### PR TITLE
Update toggle_switch.dart

### DIFF
--- a/lib/toggle_switch.dart
+++ b/lib/toggle_switch.dart
@@ -106,6 +106,9 @@ class ToggleSwitch extends StatefulWidget {
 
   /// Use toggle switch vertically
   final bool isVertical;
+  
+  /// Use icon and label vertically
+  final bool isVerticalContent;
 
   /// Set a border only to the active toggle component
   List<Border?>? activeBorders;
@@ -153,7 +156,9 @@ class ToggleSwitch extends StatefulWidget {
       this.isVertical = false,
       this.activeBorders,
       this.centerText = false,
-      this.multiLineText = false})
+      this.multiLineText = false,
+      this.isVerticalContent = false, 
+      })
       : super(key: key);
 
   @override
@@ -439,7 +444,8 @@ class _ToggleSwitchState extends State<ToggleSwitch>
                         milliseconds:
                             widget.animate ? widget.animationDuration : 0),
                     curve: widget.curve,
-                    child: Row(
+                    child: RowToColumn(
+                      isVertical: widget.isVerticalContent,
                       mainAxisAlignment: MainAxisAlignment.center,
                       children: <Widget>[
                         icon,


### PR DESCRIPTION
While running the plugin, I noticed that I could not position the icon and label on top of each other, and in this case, I solve this problem with a small touch with the RowToColumn widget, which is best used in this case.