### PR TITLE
fix: replace deprecated primaryColor with colorScheme.primary for default activeBgColor

### DIFF
--- a/lib/toggle_switch.dart
+++ b/lib/toggle_switch.dart
@@ -301,9 +301,10 @@ class _ToggleSwitchState extends State<ToggleSwitch>
     final activeFgColor = widget.activeFgColor ??
         Theme.of(context).primaryTextTheme.bodyLarge!.color;
 
-    /// Assigns active background color to default primary theme color if it's null/not provided.
+    /// Assigns active background color to the theme's `colorScheme.primary`
+    /// if it's null/not provided.
     final activeBgColor =
-        widget.activeBgColor ?? [Theme.of(context).primaryColor];
+        widget.activeBgColor ?? [Theme.of(context).colorScheme.primary];
 
     /// Assigns foreground color based on active status.
     ///


### PR DESCRIPTION

## Problem
The fallback active background color used `Theme.of(context).primaryColor`, which was deprecated in Flutter 3.x. This caused deprecation warnings and could produce unexpected colors depending on the theme configuration.

## Solution
Replace `Theme.of(context).primaryColor` with
`Theme.of(context).colorScheme.primary`, aligning with the modern Material Design 3 color system.

## Changes
- lib/toggle_switch.dart: updated default activeBgColor fallback to use `colorScheme.primary`

Fixes #100